### PR TITLE
Update the CE-Symm Benchmark

### DIFF
--- a/domain_symm_benchmark.tsv
+++ b/domain_symm_benchmark.tsv
@@ -94,7 +94,6 @@ d1gk2d_	C1
 d1gsha1	C1
 d1gtj2_	C1
 d1gtka2	C1
-d1gxmb_	C1
 d1gyza_	C1
 d1h21c_	C1
 d1h4td3	C1
@@ -1002,6 +1001,7 @@ d2ajab1	SH
 d1fz9f_	R2
 d2o8sa1	R2
 d2iolb_	R3
+d1gxmb_	R4
 d1blxb_	R5
 d1rmga_	R12
 d1z7xw_	R16

--- a/domain_symm_benchmark.tsv
+++ b/domain_symm_benchmark.tsv
@@ -472,7 +472,6 @@ d1zgha2	C1
 d1zjca1	C1
 d1zpsb_	C1
 d1zq1d3	C1
-d2a1bf_	C1
 d2a2ld_	C1
 d2a6qd_	C1
 d2a7ki1	C1
@@ -870,6 +869,7 @@ d1xq4a_	C2
 d1yioa2	C2
 d1zagd2	C2
 d1zsoa1	C2
+d2a1bf_	C2
 d2ahja_	C2
 d2ap3a1	C2
 d2au5a1	C2

--- a/domain_symm_benchmark.tsv
+++ b/domain_symm_benchmark.tsv
@@ -440,7 +440,6 @@ d1y7mb2	C1
 d1ybeb2	C1
 d1ydua1	C1
 d1ydxa2	C1
-d1yela1	C1
 d1yfnb_	C1
 d1yh5a1	C1
 d1yntg2	C1
@@ -861,6 +860,7 @@ d1xkra_	C2
 d1xmpa_	C2
 d1xmqf_	C2
 d1xq4a_	C2
+d1yela1	C2
 d1yioa2	C2
 d1zagd2	C2
 d1zsoa1	C2

--- a/domain_symm_benchmark.tsv
+++ b/domain_symm_benchmark.tsv
@@ -1001,7 +1001,7 @@ d1v0fd2	NIH
 d2b1ea_	NIH
 d1qtea1	SH
 d2ajab1	SH
-d1z7xw_	SH
 d3bsda_	R4
 d1blxb_	R5
 d1rmga_	R12
+d1z7xw_	R16

--- a/domain_symm_benchmark.tsv
+++ b/domain_symm_benchmark.tsv
@@ -82,7 +82,6 @@ d1f7va1	C1
 d1fkma2	C1
 d1fu1a1	C1
 d1fuif1	C1
-d1fz9f_	C1
 d1fzff1	C1
 d1g2ra_	C1
 d1g71b_	C1
@@ -1000,6 +999,7 @@ d1v0fd2	NIH
 d2b1ea_	NIH
 d1qtea1	SH
 d2ajab1	SH
+d1fz9f_	R2
 d2iolb_	R3
 d3bsda_	R4
 d1blxb_	R5

--- a/domain_symm_benchmark.tsv
+++ b/domain_symm_benchmark.tsv
@@ -633,7 +633,6 @@ d2ookb_	C1
 d2ot3a_	C1
 d2ou6a1	C1
 d2oy9b_	C1
-d2p0ta1	C1
 d2p3pb_	C1
 d2p5zx1	C1
 d2p62a1	C1
@@ -1000,6 +999,7 @@ d1qtea1	SH
 d2ajab1	SH
 d1fz9f_	R2
 d2o8sa1	R2
+d2p0ta1	R2
 d2iolb_	R3
 d1gxmb_	R4
 d1blxb_	R5

--- a/domain_symm_benchmark.tsv
+++ b/domain_symm_benchmark.tsv
@@ -961,6 +961,7 @@ d1ri6a_	C7
 d1tyqc_	C7
 d1xksa_	C7
 d2g02a1	C7
+d2i5ia1	C7
 d2vdka_	C7
 d1b54a_	C8
 d1cgwa4	C8
@@ -981,7 +982,6 @@ d1xrsa_	C8
 d1yrra2	C8
 d2gl5a1	C8
 d2htmc_	C8
-d2i5ia1	C8
 d3fjna_	C8
 d1i78a_	D2
 d1y0ga_	D2

--- a/domain_symm_benchmark.tsv
+++ b/domain_symm_benchmark.tsv
@@ -606,7 +606,6 @@ d2iecd_	C1
 d2if1a_	C1
 d2ijra1	C1
 d2ioja1	C1
-d2iolb_	C1
 d2iubd1	C1
 d2ixpd_	C1
 d2iyja1	C1
@@ -1001,6 +1000,7 @@ d1v0fd2	NIH
 d2b1ea_	NIH
 d1qtea1	SH
 d2ajab1	SH
+d2iolb_	R3
 d3bsda_	R4
 d1blxb_	R5
 d1rmga_	R12

--- a/domain_symm_benchmark.tsv
+++ b/domain_symm_benchmark.tsv
@@ -581,7 +581,6 @@ d2hfqa1	C1
 d2hg7a1	C1
 d2hgjk2	C1
 d2hh6a1	C1
-d2hj9c1	C1
 d2hnga1	C1
 d2hwja1	C1
 d2hyec3	C1
@@ -998,6 +997,7 @@ d2b1ea_	NIH
 d1qtea1	SH
 d2ajab1	SH
 d1fz9f_	R2
+d2hj9c1	R2
 d2o8sa1	R2
 d2p0ta1	R2
 d2iolb_	R3

--- a/domain_symm_benchmark.tsv
+++ b/domain_symm_benchmark.tsv
@@ -396,7 +396,6 @@ d1vs6i1	C1
 d1vs7s1	C1
 d1vyia_	C1
 d1w0kb1	C1
-d1w1la1	C1
 d1w2da_	C1
 d1w53a_	C1
 d1w7aa4	C1
@@ -851,6 +850,7 @@ d1vgya2	C2
 d1vi7a2	C2
 d1vq4e2	C2
 d1w0je2	C2
+d1w1la1	C2
 d1wcwa_	C2
 d1wj9a2	C2
 d1wokd1	C2

--- a/domain_symm_benchmark.tsv
+++ b/domain_symm_benchmark.tsv
@@ -702,6 +702,7 @@ d3b6na_	C1
 d3beca2	C1
 d3bhxa2	C1
 d3bp9o_	C1
+d3bsda_	C1
 d3c8wd_	C1
 d3cc7y1	C1
 d3ccdb_	C1
@@ -1001,7 +1002,6 @@ d1qtea1	SH
 d2ajab1	SH
 d1fz9f_	R2
 d2iolb_	R3
-d3bsda_	R4
 d1blxb_	R5
 d1rmga_	R12
 d1z7xw_	R16

--- a/domain_symm_benchmark.tsv
+++ b/domain_symm_benchmark.tsv
@@ -477,7 +477,6 @@ d2a9sa1	C1
 d2a9ua1	C1
 d2aj7b_	C1
 d2ajff_	C1
-d2apla1	C1
 d2auwb2	C1
 d2avua1	C1
 d2ax3a2	C1
@@ -997,6 +996,7 @@ d2b1ea_	NIH
 d1qtea1	SH
 d2ajab1	SH
 d1fz9f_	R2
+d2apla1	R2
 d2hj9c1	R2
 d2o8sa1	R2
 d2p0ta1	R2

--- a/domain_symm_benchmark.tsv
+++ b/domain_symm_benchmark.tsv
@@ -416,7 +416,6 @@ d1x0ha1	C1
 d1x3aa1	C1
 d1x40a1	C1
 d1x52a1	C1
-d1x9ga_	C1
 d1x9na3	C1
 d1x9zb_	C1
 d1xdyh_	C1
@@ -852,6 +851,7 @@ d1wj9a2	C2
 d1wokd1	C2
 d1wopa2	C2
 d1x91a_	C2
+d1x9ga_	C2
 d1x9na1	C2
 d1xb9a_	C2
 d1xcob_	C2

--- a/domain_symm_benchmark.tsv
+++ b/domain_symm_benchmark.tsv
@@ -628,7 +628,6 @@ d2nvye1	C1
 d2nwta1	C1
 d2o35a1	C1
 d2o5ha1	C1
-d2o8sa1	C1
 d2oeba1	C1
 d2ohwb_	C1
 d2ookb_	C1
@@ -1001,6 +1000,7 @@ d2b1ea_	NIH
 d1qtea1	SH
 d2ajab1	SH
 d1fz9f_	R2
+d2o8sa1	R2
 d2iolb_	R3
 d1blxb_	R5
 d1rmga_	R12

--- a/domain_symm_benchmark.tsv
+++ b/domain_symm_benchmark.tsv
@@ -25,7 +25,6 @@ d1brsd_	C1
 d1brwa3	C1
 d1brwb2	C1
 d1bsxb_	C1
-d1c3oa1	C1
 d1c4zb_	C1
 d1c78b_	C1
 d1c82a1	C1
@@ -995,6 +994,7 @@ d1v0fd2	NIH
 d2b1ea_	NIH
 d1qtea1	SH
 d2ajab1	SH
+d1c3oa1	R2
 d1fz9f_	R2
 d2apla1	R2
 d2hj9c1	R2


### PR DESCRIPTION
After the discussion of some borderline/missclassified domains of the benchmark, the cases where a general agreement exists have been updated with the consensus opinion. 

This results in 15 changes, 9 of which are open repeats (tagged as C1 before), 1 moved to the C1 group, 1 with repeat count update (from C8 to C7) and 4 reviewed cases with C2 symmetry (C1 before).

The changes are only a 6% of the total symmetric domains, but they involve domains in the **boundary** of the classification threshold (the difficult to classify, thus important region).